### PR TITLE
Specify version of eventmachine based on ruby version

### DIFF
--- a/playtypus.gemspec
+++ b/playtypus.gemspec
@@ -23,6 +23,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'coveralls', '~> 0.7.11', '>= 0.7.11'
   s.add_dependency 'pry', '~> 0.10.1', '>= 0.10.1'
   s.add_dependency 'httparty', '~> 0.11.0', '>= 0.11.0'
-  s.add_dependency 'eventmachine', '~> 1.0.3', '< 1.0.4'
+  if RUBY_VERSION >= "2.2.0"
+    s.add_dependency 'eventmachine', '~> 1.0.4', '>= 1.0.4'
+  else
+    s.add_dependency 'eventmachine', '~> 1.0.3', '< 1.0.4'
+  end
   s.add_dependency 'mocha', '~> 0.14.0', '>= 0.14.0'
 end


### PR DESCRIPTION
ruby >=2.2.0 will fail when installing eventmachine 1.0.3
ruby <2.2.0 will fail when installing eventmachine 1.0.4 or above
This commit installs a specific version of event machine based on
the version of ruby installed
