### PR TITLE
Write to specific response files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,5 @@ notifications:
   email:
     - justin.brown@rackspace.com
 script: "rake test"
+before_install:
+  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The Playtypus is an eventmachine-based command line utility that plays HTTP call
            "timestamp" : "1970-01-01T00:00:01.0000000000Z",
            "path" : "/v1/users/1",
            "verb" : "GET",
+           "request_filename" : "list_requests.log",
            "headers" : {
              "Content-Type" : "application/xml"
            }
@@ -104,6 +105,9 @@ Call logs specify arrays of JSON instructing The Playtypus what, as well as when
 4.  headers - a dictionary of headers to send
 
 5.  body - a payload in dictionary or string format
+
+6. response_filename - by default, if you specify the response-log, playtypus will log files in that folder sequentially starting from 000000000.log. If you want to specify the actual log file name, add this to your call. Note: it will ALWAYS append to the file
+
 
 ## Contributing
 

--- a/lib/playtypus/call.rb
+++ b/lib/playtypus/call.rb
@@ -7,18 +7,20 @@ module Playtypus
       :path,
       :verb,
       :headers,
-      :body
+      :body,
+      :response_filename
 
     def self.from_hash(hash)
-      return self.new(hash['timestamp'], hash['path'], hash['verb'], hash['headers'], hash['body'])
+      return self.new(hash['timestamp'], hash['path'], hash['verb'], hash['headers'], hash['body'], hash['response_filename'])
     end
 
-    def initialize(timestamp, path, verb, headers, body)
+    def initialize(timestamp, path, verb, headers, body, response_filename)
       @timestamp = Time.iso8601(timestamp)
       @path = path
       @verb = verb
       @headers = headers
       @body = body
+      @response_filename = response_filename
     end
 
     def to_hash
@@ -27,7 +29,8 @@ module Playtypus
         'path' => @path,
         'verb' => @verb,
         'headers' => @headers,
-        'body' => @body
+        'body' => @body,
+	'response_filename' => @response_filename
       }
     end
 

--- a/lib/playtypus/gateway.rb
+++ b/lib/playtypus/gateway.rb
@@ -27,12 +27,16 @@ module Playtypus
           current = Time.now.utc - @diff
           while(@position < @call_list.size)
             call = @call_list[@position]
+	    call_log_response_filename = "#{@position.to_s.rjust(10, '0')}.log"
+	    call_log_response_filename = call.response_filename unless call.response_filename.to_s.empty?
+	    file_operation = 'w+'
+	    file_operation = 'a' unless call.response_filename.to_s.empty?
             if(!(@preserve_times) || (call.timestamp <= current))
               result = @sender.send(call)
               $logger.info "#{self.class.name}: waited #{@ticks} ticks.  sent message #{call.timestamp}"
               unless @response_log.to_s.empty?
                 begin
-                  File.open("#{@response_log}/#{@position.to_s.rjust(10, '0')}.log", 'w+') do |file|
+			File.open("#{@response_log}/#{call_log_response_filename}", file_operation) do |file|
                       file.write(JSON.pretty_generate({ 'code' => result.response.code, 'headers' => result.headers.to_hash, 'body' => result.parsed_response}))
                   end
                 rescue => e

--- a/playtypus.gemspec
+++ b/playtypus.gemspec
@@ -23,7 +23,9 @@ Gem::Specification.new do |s|
   s.add_dependency 'coveralls', '~> 0.7.11', '>= 0.7.11'
   s.add_dependency 'pry', '~> 0.10.1', '>= 0.10.1'
   s.add_dependency 'httparty', '~> 0.11.0', '>= 0.11.0'
-  if RUBY_VERSION >= "2.2.0"
+  if RUBY_VERSION >= "2.4.0"
+    s.add_dependency 'eventmachine', '~> 1.2.4', '>=1.2.5'
+  elsif RUBY_VERSION >= "2.2.0"
     s.add_dependency 'eventmachine', '~> 1.0.4', '>= 1.0.4'
   else
     s.add_dependency 'eventmachine', '~> 1.0.3', '< 1.0.4'

--- a/test/call_test.rb
+++ b/test/call_test.rb
@@ -10,7 +10,8 @@ class CallTest < Playtypus::Test
       verb = "POST"
       headers = { 'header1' => 'foo', 'header2' => 'bar'}
       body = { 'body1' => 'fizz', 'body2' => 'buzz', 'list1' => [ '1', '2', '3'] }
-      call = Playtypus::Call.new(timestamp.iso8601, path, verb, headers, body)
+      request_log = {'response_filename'=> 'request_log.log'}
+      call = Playtypus::Call.new(timestamp.iso8601, path, verb, headers, body, request_log)
       assert_equal timestamp.iso8601, call.timestamp.iso8601
       assert_equal path, call.path
       assert_equal verb, call.verb
@@ -22,6 +23,7 @@ class CallTest < Playtypus::Test
       assert_equal verb, from_hash['verb']
       assert_equal headers, from_hash['headers']
       assert_equal body, from_hash['body']
+      assert_equal request_log, from_hash['response_filename']
       to_s = call.to_s
       hash_from_s = JSON.parse(to_s)
       assert_equal timestamp.to_s, hash_from_s['timestamp']
@@ -37,7 +39,7 @@ class CallTest < Playtypus::Test
       verb = "GET"
       headers = nil
       body = nil
-      call = Playtypus::Call.new(timestamp.iso8601, path, verb, headers, body)
+      call = Playtypus::Call.new(timestamp.iso8601, path, verb, headers, body, nil)
       assert_equal timestamp.iso8601, call.timestamp.iso8601
       assert_equal path, call.path
       assert_equal verb, call.verb
@@ -64,12 +66,14 @@ class CallTest < Playtypus::Test
       verb = "GET"
       headers = nil
       body = nil
+      response_filename = nil,
       hash = {
         'timestamp' => timestamp.iso8601,
         'path' => path,
         'verb' => verb,
         'headers' => headers,
-        'body' => body
+        'body' => body,
+        'response_filename' => response_filename,
       }
       call = Playtypus::Call.from_hash hash
       assert_equal timestamp.iso8601, call.timestamp.iso8601

--- a/test/gateway_test.rb
+++ b/test/gateway_test.rb
@@ -83,9 +83,11 @@ class GatewayTest < Playtypus::Test
 
   def build_mock_call(timestamp = Time.now)
     return (Class.new Object do
-      attr_reader :timestamp
+              attr_reader :timestamp
+              attr_reader :response_filename
       def initialize(ts)
         @timestamp = ts
+        @response_filename = nil
       end
     end).new(timestamp)
   end

--- a/test/http_sender_test.rb
+++ b/test/http_sender_test.rb
@@ -10,7 +10,7 @@ class HttpSenderTest < Playtypus::Test
 
   def test_send_get
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get', 'GET', nil, nil) 
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get', 'GET', nil, nil, nil) 
     sender.stubs(:send_http).with('get', 'http://169.169.169.169/get', { :headers => nil, :body => nil }).returns(200)
     response = sender.send call
     assert_equal 200, response
@@ -18,7 +18,7 @@ class HttpSenderTest < Playtypus::Test
 
   def test_send_get_encoded
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get/foo\bar', 'GET', nil, nil) 
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get/foo\bar', 'GET', nil, nil, nil) 
     sender.stubs(:send_http).with('get', 'http://169.169.169.169/get/foo%5Cbar', { :headers => nil, :body => nil }).returns(200)
     response = sender.send call
     assert_equal 200, response
@@ -26,7 +26,7 @@ class HttpSenderTest < Playtypus::Test
 
   def test_send_get_fail_returns_nil
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get/fail', 'GET', nil, nil) 
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/get/fail', 'GET', nil, nil, nil) 
     sender.stubs(:send_http).with('get', 'http://169.169.169.169/get/fail', { :headers => nil, :body => nil }).raises('fail!!!')
     response = sender.send call
     assert_nil response
@@ -34,18 +34,19 @@ class HttpSenderTest < Playtypus::Test
 
   def test_send_post
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
-    body = { 'foo' => 'bar' }.to_json
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/post', 'POST', nil, body) 
-    sender.stubs(:send_http).with('post', 'http://169.169.169.169/post', { :body => body, :headers => nil }).returns(201)
+    headers = { 'fizz' => 'buzz'}
+    body = 'foobar'
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/put/1', 'POST', headers, body, ' ') 
+    sender.stubs(:send_http).with('post', 'http://169.169.169.169/put/1', { :headers => headers, :body => body }).returns(202)
     response = sender.send call
-    assert_equal 201, response
+    assert_equal 202, response
   end
 
   def test_send_put
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
     headers = { 'fizz' => 'buzz'}
     body = 'foobar'
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/put/1', 'PUT', headers, body) 
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/put/1', 'PUT', headers, body, ' ') 
     sender.stubs(:send_http).with('put', 'http://169.169.169.169/put/1', { :headers => headers, :body => body }).returns(202)
     response = sender.send call
     assert_equal 202, response
@@ -53,8 +54,8 @@ class HttpSenderTest < Playtypus::Test
 
   def test_send_delete
     sender = Playtypus::HttpSender.new('http://169.169.169.169')
-    call = Playtypus::Call.new(Time.now.utc.iso8601, '/delete/2', 'DELETE', nil, nil)
-    sender.stubs(:send_http).with('delete', 'http://169.169.169.169/delete/2', { :headers => nil, :body => nil }).returns(204)
+    call = Playtypus::Call.new(Time.now.utc.iso8601, '/delete/2', 'DELETE', nil, nil, nil)
+    sender.stubs(:send_http).with('delete', 'http://169.169.169.169/delete/2', { :headers => nil, :body => nil}).returns(204)
     response = sender.send call
     assert_equal 204, response
   end


### PR DESCRIPTION
This adds the ability to specify which file to write the
response to, instead of the incrementing numebers in a folder.
If you do not specify a specific file, the behavior is unchanged.