### PR TITLE
 This is a combination of 2 commits.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+#
+FROM fedora:latest
+
+RUN /bin/dnf install -yq deltarpm && \ 
+ dnf install -y git \
+		    ruby-2.4.1 \
+                    rubygem-rake \
+                    ruby-devel \
+                    openssl \
+                    openssl-devel \
+                    redhat-rpm-config \
+                    gcc-c++
+RUN dnf -y groupinstall development-tools
+
+#    dnf clean all
+RUN /usr/bin/gem install rake &&  \
+    /usr/bin/gem install bundle && \ 
+    /usr/bin/gem install json
+
+ENV HOME /home/user
+
+RUN useradd  user -d $HOME \
+	&& chown -R user $HOME
+
+WORKDIR $HOME
+USER user
+RUN /usr/bin/git clone https://github.com/rackspaceautomationco/playtypus.git /home/user/playtypus
+RUN cd /home/user/playtypus && \
+    rake build && \
+    gem install /home/user/playtypus/pkg/playtypus-*
+
+
+ENTRYPOINT [ "/home/user/bin/playtypus" ]
+CMD ["--help"]
+

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Call logs specify arrays of JSON instructing The Playtypus what, as well as when
 6. response_filename - by default, if you specify the response-log, playtypus will log files in that folder sequentially starting from 000000000.log. If you want to specify the actual log file name, add this to your call. Note: it will ALWAYS append to the file
 
 
+## To run via docker image:
+```
+docker run  -v /full/path/to/repo/folder:/home/user/folder --name playtypus myrepo/playtypus play -c /home/user/folder/calls.json -h https://<url>:<port> -r /home/user/folder/responses
+```
 ## Contributing
 
 1.  Fork/clone The Playtypus repo

--- a/lib/playtypus/http_sender.rb
+++ b/lib/playtypus/http_sender.rb
@@ -1,6 +1,8 @@
 require 'json'
 require 'httparty'
 require 'uri'
+require 'rexml/document'
+include REXML
 
 module HTTParty
   class Parser
@@ -61,13 +63,23 @@ module Playtypus
   end
 
   def transform_payload(input)
-    result = nil
+    result = input
     begin
-      result = JSON.pretty_generate(input)
+      result = JSON.pretty_generate(input) unless is_xml(input)
     rescue
-      result = input
     end
     return result
+  end
+
+  def is_xml(input)
+    isxml = nil
+    begin
+      Document.new(input)
+      isxml=true
+    rescue
+      isxml=false
+    end
+    return isxml
   end
 
 end


### PR DESCRIPTION
Do not pretty_generate body if content is json


Currently, ALL content in body (unless the body is malformed JSON, but that should error out anyway when we load the JSON call file) will go through pretty_generate. That is good, unless the body of the content is raw XML and the API you are calling chokes because of the escaped quotation marks at the beginning and end, since it is not valid xml.
Example snippet from call JSON:
```
"body":"<create>yay</create>"
```
playtypus will then pass the following as the body:
```
{:body=>"\"<create>yay</create>\""}
```
This seems incorrect if passing raw xml. If you WANT a quotation mark at the beginning and end of your xml in the body, I think you should explicitly add it in your call. Having quotes in your xml at the beginning and end, such as: 
```
"<create>yay</create>"
```
 is not valid XML.
I thought also about checking the headers to see if the content type is xml, and if so skip the generate. That seemed a little more complicated than this. I also wanted to hold off adding yet another option to the JSON call file. This also is not perfect but at least works in my test case. This is just one way to attempt to fix this, and I am definitely open to better ways to go about this.